### PR TITLE
add "LLC" to company name

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       crossorigin="anonymous"
     />
 
-    <title>Swamp Optics</title>
+    <title>Swamp Optics, LLC</title>
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">


### PR DESCRIPTION
The official name of the company is Swamp Optics, LLC